### PR TITLE
TST, MAINT: expand OpenBLAS version checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 
 env:
   global:
+    - OpenBLAS_version=0.3.5
     - WHEELHOUSE_UPLOADER_USERNAME=travis.numpy
     # The following is generated with the command:
     # travis encrypt -r numpy/numpy WHEELHOUSE_UPLOADER_SECRET=tH3AP1KeY

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,6 @@ variables:
   # OpenBLAS_version should be updated
   # to match numpy-wheels repo
   OpenBLAS_version: 0.3.7.dev
-  TEST_GET_CONFIG: import numpy, ctypes; dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__); get_config = dll.openblas_get_config; get_config.restype=ctypes.c_char_p; res = get_config(); print('OpenBLAS get_config returned', str(res)); assert b'OpenBLAS $(OpenBLAS_version)' in res
 
 jobs:
 - job: Linux_Python_36_32bit_full_with_asserts
@@ -30,7 +29,7 @@ jobs:
            python3 -m pip install . && \
            F77=gfortran-5 F90=gfortran-5 \
            CFLAGS='-UNDEBUG -std=c99' python3 runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml && \
-           cd .. && python3 -c \"$(TEST_GET_CONFIG)\""
+           python3 tools/openblas_support.py --check_version $(OpenBLAS_version)"
     displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -108,7 +107,7 @@ jobs:
     displayName: 'Run Refuide Check'
   - script: python runtests.py -n --mode=full -- -rsx --junitxml=junit/test-results.xml
     displayName: 'Run Full NumPy Test Suite'
-  - bash: pushd . && cd .. && python -c "$(TEST_GET_CONFIG)" && popd
+  - bash: python tools/openblas_support.py --check_version $(OpenBLAS_version)
     displayName: 'Verify OpenBLAS version'
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/shippable.yml
+++ b/shippable.yml
@@ -47,6 +47,8 @@ build:
     - extra_directories=($SHIPPABLE_REPO_DIR/build/*scripts*)
     - extra_path=$(printf "%s:" "${extra_directories[@]}")
     - export PATH="${extra_path}${PATH}"
+    # check OpenBLAS version
+    - python tools/openblas_support.py --check_version 0.3.5
     # run the test suite
     - python runtests.py -- -rsx --junit-xml=$SHIPPABLE_REPO_DIR/shippable/testresults/tests.xml -n 2 --durations=10
 

--- a/tools/openblas_support.py
+++ b/tools/openblas_support.py
@@ -192,6 +192,22 @@ def test_setup(arches):
             raise RuntimeError('Could not setup %s' % arch)
         print(target)
 
+def test_version(expected_version):
+    """
+    Assert that expected OpenBLAS version is
+    actually available via NumPy
+    """
+    import numpy
+    import ctypes
+
+    dll = ctypes.CDLL(numpy.core._multiarray_umath.__file__)
+    get_config = dll.openblas_get_config
+    get_config.restype=ctypes.c_char_p
+    res = get_config()
+    print('OpenBLAS get_config returned', str(res))
+    check_str = b'OpenBLAS %s' % expected_version[0].encode()
+    assert check_str in res
+
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(
@@ -199,8 +215,12 @@ if __name__ == '__main__':
                     'architecture')
     parser.add_argument('--test', nargs='*', default=None,
         help='Test different architectures. "all", or any of %s' % ARCHITECTURES)
+    parser.add_argument('--check_version', nargs=1, default=None,
+        help='Check provided OpenBLAS version string against available OpenBLAS')
     args = parser.parse_args()
-    if args.test is None:
+    if args.check_version is not None:
+        test_version(args.check_version)
+    elif args.test is None:
         print(setup_openblas())
     else:
         if len(args.test) == 0 or 'all' in args.test:

--- a/tools/pypy-test.sh
+++ b/tools/pypy-test.sh
@@ -45,4 +45,4 @@ pypy3/bin/pypy3 runtests.py --show-build-log -- -rsx \
 echo Make sure the correct openblas has been linked in
 
 pypy3/bin/pip install .
-(cd pypy3; bin/pypy3 -c "$TEST_GET_CONFIG")
+pypy3/bin/pypy3 tools/openblas_support.py --check_version "$OpenBLAS_version"

--- a/tools/travis-before-install.sh
+++ b/tools/travis-before-install.sh
@@ -4,6 +4,15 @@ uname -a
 free -m
 df -h
 ulimit -a
+
+if [ -n "$PPC64_LE" ]; then
+  pwd
+  ls -ltrh
+  target=$(python tools/openblas_support.py)
+  sudo cp -r $target/64/lib/* /usr/lib
+  sudo cp $target/64/include/* /usr/include
+fi
+
 mkdir builds
 pushd builds
 
@@ -25,11 +34,6 @@ if [ -n "$INSTALL_PICKLE5" ]; then
   pip install pickle5
 fi
 
-if [ -n "$PPC64_LE" ]; then
-  target=$(python tools/openblas_support.py)
-  sudo cp -r $target/64/lib/* /usr/lib
-  sudo cp $target/64/include/* /usr/include
-fi
 
 pip install --upgrade pip setuptools
 pip install nose pytz cython pytest

--- a/tools/travis-test.sh
+++ b/tools/travis-test.sh
@@ -81,6 +81,11 @@ run_test()
   INSTALLDIR=$($PYTHON -c \
     "import os; import numpy; print(os.path.dirname(numpy.__file__))")
   export PYTHONWARNINGS=default
+
+  if [ -n "$PPC64_LE" ]; then
+    $PYTHON ../tools/openblas_support.py --check_version $OpenBLAS_version
+  fi
+
   if [ -n "$RUN_FULL_TESTS" ]; then
     export PYTHONWARNINGS="ignore::DeprecationWarning:virtualenv"
     $PYTHON ../runtests.py -n -v --durations 10 --mode=full $COVERAGE_FLAG


### PR DESCRIPTION
* add a function to tools/openblas_support.py
that may be used to test OpenBLAS version
available through NumPy in a manner agnostic
to any specific CI service

* expand OpenBLAS version checking to include
ppc64le and POWER8 CI runs

* Azure CI config no longer uses a single-line
280-character Python "program" assigned to an
environment variable to check OpenBLAS version;
instead, it now leverages tools/openblas_support.py
to perform the same operation using a conventional
Python function

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
